### PR TITLE
Add markdown folder scan utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ This contains everything you need to run your app locally.
 
 **Prerequisites:**  Node.js
 
-
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Scan a folder for Markdown files
+
+Use the provided script to recursively list all `.md` files in a directory:
+
+```bash
+npm run scan-md ./path/to/folder
+```
+
+This will print every Markdown file found inside the folder and its subdirectories.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "scan-md": "node scanMarkdown.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/scanMarkdown.js
+++ b/scanMarkdown.js
@@ -1,0 +1,34 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function scanDir(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const markdownFiles = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const subFiles = await scanDir(fullPath);
+      markdownFiles.push(...subFiles);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      markdownFiles.push(fullPath);
+    }
+  }
+  return markdownFiles;
+}
+
+async function main() {
+  const startDir = process.argv[2] || '.';
+  try {
+    const files = await scanDir(startDir);
+    console.log(`Found ${files.length} Markdown file(s):`);
+    for (const file of files) {
+      console.log(file);
+    }
+  } catch (err) {
+    console.error('Error scanning directory:', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a Node.js script `scanMarkdown.js` that recursively lists `.md` files
- expose the script via `npm run scan-md`
- document how to use the script in README

## Testing
- `npm run scan-md .`
- `npm run build` *(fails: vite not found)*