### PR TITLE
Add zipped multi-file download

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,11 +12,13 @@ const App: React.FC = () => {
   const [currentError, setCurrentError] = useState<string | null>(null);
   const [fileExtensionConfig, setFileExtensionConfig] = useState<string>(".md");
   const [sourceFolderNameForDisplay, setSourceFolderNameForDisplay] = useState<string | null>(null);
+  const [masterDocumentParts, setMasterDocumentParts] = useState<string[]>([]);
 
   const processFolder = useCallback(async (selectedFiles: FileList, folderNameFromInputHeuristic: string) => {
     setIsLoading(true);
     setCurrentError(null);
     setProcessedDocuments([]);
+    setMasterDocumentParts([]);
 
     // Convert FileList to an array immediately.  Some browsers mutate the
     // FileList when the input value is cleared, so working with a copy ensures
@@ -110,6 +112,18 @@ const App: React.FC = () => {
 
     console.log("FINISHED FOLDER PROCESSING LOOP.");
     setProcessedDocuments(newProcessedDocuments);
+    const aggregatedContent = newProcessedDocuments.map(doc => `### ${doc.sourcePath}\n\n${doc.textContent}`).join("\n\n");
+    const partLength = Math.ceil(aggregatedContent.length / 5);
+    const parts: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const start = i * partLength;
+      if (start < aggregatedContent.length) {
+        parts.push(aggregatedContent.slice(start, Math.min(start + partLength, aggregatedContent.length)));
+      } else {
+        parts.push("");
+      }
+    }
+    setMasterDocumentParts(parts);
     setSummary({
       totalFilesFound: totalFilesFoundInSelection,
       filesSuccessfullyProcessed: filesProcessedSuccessfully,
@@ -171,6 +185,7 @@ const App: React.FC = () => {
             documents={processedDocuments}
             summary={summary}
             isLoading={isLoading}
+            masterDocumentParts={masterDocumentParts}
           />
         </main>
         <footer className="text-center mt-12 py-6 border-t border-slate-700">

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ npm run scan-md ./path/to/folder
 ```
 
 This will print every Markdown file found inside the folder and its subdirectories.
+
+## Descarga de documentación procesada
+
+Al finalizar el procesamiento, la aplicación permite descargar la documentación
+generada en un archivo ZIP que contiene cinco partes de tamaño similar.

--- a/components/ResultsDisplay.tsx
+++ b/components/ResultsDisplay.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import JSZip from 'jszip';
 import { ProcessedDocument, ProcessSummary } from '../types';
 
 // Simple ChevronDown Icon SVG
@@ -60,9 +61,10 @@ interface ResultsDisplayProps {
   documents: ProcessedDocument[];
   summary: ProcessSummary | null;
   isLoading: boolean;
+  masterDocumentParts: string[];
 }
 
-export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ documents, summary, isLoading }) => {
+export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ documents, summary, isLoading, masterDocumentParts }) => {
   if (isLoading) {
     return (
       <div className="text-center p-10">
@@ -118,6 +120,28 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ documents, summa
             {documents.map((doc, index) => (
               <DocumentItem key={`${doc.sourcePath}-${index}`} document={doc} />
             ))}
+          </div>
+          <div className="text-right mt-4">
+            <button
+              onClick={async () => {
+                const zip = new JSZip();
+                masterDocumentParts.forEach((content, index) => {
+                  zip.file(`documento_${index + 1}.md`, content);
+                });
+                const blob = await zip.generateAsync({ type: 'blob' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'documentacion_partes.zip';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+              }}
+              className="px-4 py-2 bg-sky-600 text-white rounded-md hover:bg-sky-700 focus:outline-none"
+            >
+              Descargar Documentación (ZIP)
+            </button>
           </div>
         </div>
       )}

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/jszip": "^3.10.2",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
## Summary
- split aggregated documentation into five parts in `App.tsx`
- pass document parts to `ResultsDisplay`
- use JSZip to generate a ZIP with the five markdown files
- update README with new download info
- declare jszip dependencies

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*